### PR TITLE
Prepare release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Todos los cambios notables a este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2021-04-09
+### Added
+- Se actualiza SDK de PHP a versión 2.0, por lo que ahora se usa la API v1.2 de Transbank.
+
+### Fixed
+- Se debe resolver posible problema de perder sesión al volver del medio de pago.
+
 ## [1.0.0] - 2020-11-03
 ### Added
 Se agrega soporte para REST. Basado en la versión 2.0.9 del plugin Virtuemart SOAP.


### PR DESCRIPTION
### Added
- Se actualiza SDK de PHP a versión 2.0, por lo que ahora se usa la API v1.2 de Transbank.

### Fixed
- Se debe resolver posible problema de perder sesión al volver del medio de pago.
