### PR TITLE
refactor: add image in payment method configuration panel

### DIFF
--- a/src/transbank_webpay_rest/fields/webpaylogo.php
+++ b/src/transbank_webpay_rest/fields/webpaylogo.php
@@ -19,7 +19,7 @@ class JFormFieldWebpayLogo extends JFormField
         $url = 'https://www.transbank.cl/';
         $logo = '<img src="' . JURI::root() . 'plugins/vmpayment/transbank_webpay_rest/transbank_webpay_rest/assets/images/logo-small-new.png" width="100" height="91"/>';
         $html = '<p>
-                    <a target="_blank" href="'.$url.'"  >'.$logo.'</a>
+                    <a target="_blank" href="' . $url . '"  >' . $logo . '</a>
                 </p>
                 <span>
                     <button class="btn btn-lg btn-danger" data-toggle="modal" data-target="#tb_commerce_mod_info">Información</button>

--- a/src/transbank_webpay_rest/fields/webpaylogo.php
+++ b/src/transbank_webpay_rest/fields/webpaylogo.php
@@ -17,7 +17,7 @@ class JFormFieldWebpayLogo extends JFormField
     {
         vmJsApi::addJScript('/plugins/vmpayment/transbank_webpay_rest/transbank_webpay_rest/assets/js/admin.js');
         $url = 'https://www.transbank.cl/';
-        $logo = '<img src="/plugins/vmpayment/transbank_webpay_rest/transbank_webpay_rest/assets/images/logo-small-new.png" width="100" height="91"/>';
+        $logo = '<img src="' . JURI::root() . 'plugins/vmpayment/transbank_webpay_rest/transbank_webpay_rest/assets/images/logo-small-new.png" width="100" height="91"/>';
         $html = '<p>
                     <a target="_blank" href="'.$url.'"  >'.$logo.'</a>
                 </p>


### PR DESCRIPTION
The path where Webpay logo image is located was changed. With this change the Transbank Webpay logo can now be seen in the payment method configuration panel.

> Before the changes
![Captura de pantalla 2024-09-03 a la(s) 5 12 36 p  m](https://github.com/user-attachments/assets/39215a5f-028a-4f25-9158-76847da4b380)

> After the changes
![Captura de pantalla 2024-09-03 a la(s) 5 12 27 p  m](https://github.com/user-attachments/assets/24049883-9525-4cc4-92e0-94c0bc134881)

